### PR TITLE
Add Schneems, maintainer of Sprockets to Repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@
   * "Walking the Talk: Adopting and Adapting Sustainable Scientific Software Development processes in a Small Biology Lab" ([paper](http://dx.doi.org/10.5334/jors.35))
 * [@nolanlawson](https://github.com/nolanlawson), [PouchDB](https://github.com/pouchdb/pouchdb) 
   * "What it feels like to be an open-source maintainer" ([post](https://nolanlawson.com/2017/03/05/what-it-feels-like-to-be-an-open-source-maintainer/))
+* [@Schneems](https://github.com/Schneems), [Sprockets](https://github.com/rails/sprockets), [CodeTriage](https://www.codetriage.com)
+  * "Saving Sprockets - What happens when a maintainer leaves" ([video](https://www.youtube.com/watch?v=qxaE8yblHPk), [post with transcript](https://www.schneems.com/2016/05/31/saving-sprockets.html))
 * [@Seldaek](https://github.com/Seldaek), [Composer](https://github.com/composer/composer)
   * "Behind the Scenes of Maintaining an Open Source Project" ([video](https://www.youtube.com/watch?v=Ci_I0ATr748))
 * [@tgamblin](https://github.com/tgamblin), [Spack](https://github.com/spack/spack)


### PR DESCRIPTION
While the talk is “Saving Sprockets” the content is 100% about open source maintenance.
