### PR TITLE
Add "Request’s Past, Present and Future"

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@
   * "Maintainer Stories: Katrina Owen" ([video](https://www.youtube.com/watch?v=MjKwvdF7SrA))
 * [@lmccart](https://github.com/lmccart), [p5.js](https://github.com/processing/p5.js)
   * "Design, Software, and Open Source" ([interview](https://changelog.com/rfc/19))
+* [@mikeal](https://github.com/mikeal), [request](https://github.com/request/request/)
+  * "Request's Past, Present and Future" ([post](https://github.com/request/request/issues/3142))
 * [@MikeMcQuaid](https://github.com/MikeMcQuaid), [Homebrew](https://github.com/Homebrew)
   * "The Open Source Contributor Funnel" ([post](https://mikemcquaid.com/2018/08/14/the-open-source-contributor-funnel-why-people-dont-contribute-to-your-open-source-project/), [video](https://www.youtube.com/watch?v=OsOZpF6LFcw), [slides](http://mikemcquaid.com/talks/the-open-source-contributor-funnel/))
 * [@mlavin](https://github.com/mlavin), [Django](https://github.com/django/django)


### PR DESCRIPTION
Loved [this post](https://github.com/request/request/issues/3142) from Mikeal as to why he's putting `request` into maintenance mode, despite its popularity (ht @zeke):

> The best thing for these new modules is for request to slowly fade away, eventually becoming just another memory of that legacy stack. Taking the position request has now and leveraging it for a bigger share of the next generation of developers would be a disservice to those developers as it would drive them away from better modules that don’t have the burden of request’s history.

I haven't seen many examples of maintainers stepping away from a project in order to let new ones flourish.

With physical infrastructure, you have one central body (government) who is able to look at the ecosystem holistically and analyze the tradeoffs of maintenance. With digital infrastructure, it's a patchwork of many different people and their projects, often with competing agendas. I wonder how we incentivize this type of coordination around maintenance within an inherently decentralized ecosystem.