### PR TITLE
Add Lorenzo's React Native Community talk

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@
   * "Maintainer Stories: Jess Frazelle ([interview](https://github.com/open-source/stories/jessfraz))
 * [@jodosha](https://github.com/jodosha), [Hanami](https://github.com/hanami)
   * "Lessons Learned While Building Hanami" ([video](https://www.youtube.com/watch?v=0RyitUKfUFE), [slides](https://speakerdeck.com/jodosha/lessons-learned-while-building-hanami))
+* [@kelset](https://github.com/kelset), [React Native](https://github.com/facebook/react-native)
+  * "All Hands on Deck: The React Native Community Experience" ([video](https://youtu.be/OVzMw3vYrDI))
 * [@kennethreitz](https://github.com/kennethreitz), [requests](https://github.com/requests/requests)
   * "The Reality of Developer Burnout" ([post](https://www.kennethreitz.org/essays/the-reality-of-developer-burnout))
 * [@kentcdodds](https://github.com/kentcdodds), [various](https://github.com/kentcdodds)


### PR DESCRIPTION
`kelset` recently gave a talk at Chain React 2019 about how he became a React Native maintainer as a non-FB employee, and lessons learned as an "owner" for the [React Native Community](https://github.com/react-native-community).